### PR TITLE
Fix error: "Invalid value 'armeabi' in $(AndroidSupportedAbis). This ABI is no longer supported."

### DIFF
--- a/GoogleNativeLogin/GoogleNativeLogin/GoogleNativeLogin.Droid/GoogleNativeLogin.Droid.csproj
+++ b/GoogleNativeLogin/GoogleNativeLogin/GoogleNativeLogin.Droid/GoogleNativeLogin.Droid.csproj
@@ -20,7 +20,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
-    <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
+    <AndroidSupportedAbis>arm64-v8a,armeabi-v7a,x86,x86_64</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions />
     <MandroidI18n />
     <JavaMaximumHeapSize />


### PR DESCRIPTION
The "armeabi" Android ABI version is outdated, so the project doesn't build on a fresh checkout.
The solution is to update the list of supported ABIs

The full error you get for GoogleNativeLogin.Droid is:
"Invalid value 'armeabi' in $(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties to remove the old value. If the properties page does not show an 'armeabi' checkbox, un-check and re-check one of the other ABIs and save the changes."

Historically the NDK supported ARMv5 (armeabi), and 32-bit and 64-bit MIPS, but support for these ABIs was removed in NDK r17. https://developer.android.com/ndk/guides/abis